### PR TITLE
Move Puppet::Util::Diff include to code that's directly using it

### DIFF
--- a/lib/puppet/type/concat_build.rb
+++ b/lib/puppet/type/concat_build.rb
@@ -150,6 +150,8 @@ Puppet::Type.newtype(:concat_build) do
   end
 
   newproperty(:order, :array_matching => :all) do
+    include Puppet::Util::Diff
+
     desc "Array containing ordering info for build"
 
     defaultto ["*"]

--- a/lib/puppet/type/concat_fragment.rb
+++ b/lib/puppet/type/concat_fragment.rb
@@ -17,8 +17,6 @@
 # this program.  If not, see <http://www.gnu.org/licenses/>.
 #
 
-include Puppet::Util::Diff
-
 Puppet::Type.newtype(:concat_fragment) do
   @doc = "Create a concat fragment"
 


### PR DESCRIPTION
Move Puppet::Util::Diff include to code that's directly using it, fixes occasional load order errors

While running with puppet apply, I was hitting this:
err: /Stage[main]/Dns/Concat_build[dns_zones]: Could not evaluate: undefined method `diff' for #Puppet::Type::Concat_build::Order:0x7f69c5711f48
