### PR TITLE
Use Client vardir, not the puppet masters vardir

### DIFF
--- a/lib/puppet/parser/functions/concat_output.rb
+++ b/lib/puppet/parser/functions/concat_output.rb
@@ -15,7 +15,7 @@
 #
 module Puppet::Parser::Functions
     newfunction(:concat_output, :type => :rvalue, :doc => "Returns the output file for a given concat build.") do |args|
-        vardirfact = lookupvar('puppet_vardir')
+        vardirfact = lookupvar('::puppet_vardir')
 
         if vardirfact.nil? || vardirfact == :undefined
             clientvardir = Puppet[:vardir]


### PR DESCRIPTION
The function is meant to output the path on the client to the output file. If a client uses a different Puppet[:vardir] however, the code will fail by using the Puppet Masters Puppet[:vardir] - as expected of functions.

This change will use the stdlib puppet_vardir fact to retrieve the proper vardir value. In absence of the stdlib fact, it'll fall back to old behaviour.
